### PR TITLE
Bump Terraform to 1.1.4 & variables isolation for os arch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,8 +9,8 @@ on:
       - 'feature*'
       - 'feature_*'
       - 'feature/*'
-      - 'hotfix*'
       - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 2 * * *'
@@ -21,12 +21,12 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.terraform'
         fetch-depth: 0
@@ -34,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.terraform'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -44,16 +45,16 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 8
+      max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.terraform'
 
@@ -69,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.terraform'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.terraform'
 
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.terraform'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,23 +16,31 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 terraform_app: terraform
-terraform_version: 1.1.3
-terraform_osarch: linux_amd64
+terraform_version: 1.1.4
+terraform_os: linux
+terraform_arch: amd64
 terraform_dl_url: https://releases.hashicorp.com
 terraform_dl_loc: /tmp
 terraform_bin_path: /usr/local/bin
+terraform_file_owner: root
+terraform_file_group: root
+terraform_file_mode: '0755'
 ```
 
 ### Variables table:
 
-Variable           | Value (default)                  | Description
------------------- | -------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------
-terraform_app      | terraform                        | Defines the app to install i.e. **terraform**
-terraform_version  | 1.1.3                            | Defined to dynamically fetch the desired version to install. Defaults to: **1.1.3**
-terraform_osarch   | linux_amd64                      | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux_amd64**
-terraform_dl_url   | <https://releases.hashicorp.com> | Defines URL to download the terraform binary from.
-terraform_dl_loc   | /tmp                             | Defined to dynamically set where to place the binary archive for `terraform` temporarily. Defaults to: **/tmp**
-terraform_bin_path | /usr/local/bin                   | Defined to dynamically set the appropriate path to store terraform binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+Variable             | Description
+-------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------
+terraform_app        | Defines the app to install i.e. **terraform**
+terraform_version    | Defined to dynamically fetch the desired version to install. Defaults to: **1.1.4**
+terraform_os         | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
+terraform_arch       | Defines os architecture. Used to set the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
+terraform_dl_url     | Defines URL to download the terraform binary from.
+terraform_dl_loc     | Defined to dynamically set where to place the binary archive for `terraform` temporarily. Defaults to: **/tmp**
+terraform_bin_path   | Defined to dynamically set the appropriate path to store terraform binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+terraform_file_owner | Owner for the binary file of terraform.
+terraform_file_group | Group for the binary file of terraform.
+terraform_file_mode  | Mode for the binary file of terraform.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,12 @@
 # defaults file for terraform
 
 terraform_app: terraform
-terraform_version: 1.1.3
-terraform_osarch: linux_amd64
+terraform_version: 1.1.4
+terraform_os: linux
+terraform_arch: amd64
 terraform_dl_url: https://releases.hashicorp.com
 terraform_dl_loc: /tmp
 terraform_bin_path: /usr/local/bin
+terraform_file_owner: root
+terraform_file_group: root
+terraform_file_mode: '0755'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+  - name: ${DISTRO:-ubuntu-20.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=ansible-role-terraform
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-terraform
 sonar.coverage.exclusions=**/**
-sonar.python=3
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -3,43 +3,26 @@
 
 - name: Debian/Ubuntu Family | Downloading archive for {{ terraform_app }} {{ terraform_version }} temporarily to {{ terraform_dl_loc }}
   get_url:
-    url: "{{ terraform_dl_url }}/{{ terraform_app }}/{{ terraform_version }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    url: "{{ terraform_dl_url }}/{{ terraform_app }}/{{ terraform_version }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     dest: "{{ terraform_dl_loc }}"
 
-# - name: Install python3-apt on Debian based systems, required for package_facts.
-#   apt:
-#     name: python3-apt
-#     state: present
-#     force_apt_get: yes
-#     update_cache: yes
-
-# - name: Gather package facts to verify if unzip is installed on Debian based systems
-#   package_facts:
-#     manager: apt
-
-- name: Debian/Ubuntu Family | Install unzip if it is currently not in an installed state
+- name: Debian/Ubuntu Family | Install unzip if it is currently not in installed state
   apt:
     name: unzip
     state: present
     force_apt_get: yes
     update_cache: yes
-    # when: packages['unzip'] is not defined
 
-- name: Debian/Ubuntu Family | Extract {{ terraform_app }} archive
+- name: Debian/Ubuntu Family | Unarchive {{ terraform_app }} {{ terraform_version }}
   unarchive:
-    src: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    src: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     dest: "{{ terraform_bin_path }}"
+    owner: "{{ terraform_file_owner }}"
+    group: "{{ terraform_file_group }}"
+    mode: "{{ terraform_file_mode }}"
     remote_src: true
 
-# - name: Uninstalling unzip as it was originally not in installed state on Debian based systems.
-#   apt:
-#     name: unzip
-#     state: absent
-#     force_apt_get: yes
-#     update_cache: yes
-#   when: packages['unzip'] is not defined
-
-- name: Debian/Ubuntu Family | Remove {{ terraform_app }} archive
+- name: Debian/Ubuntu Family | Remove {{ terraform_app }} archive file
   file:
-    path: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    path: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     state: absent

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -3,27 +3,26 @@
 
 - name: EL Family | Downloading archive for {{ terraform_app }} {{ terraform_version }} temporarily to {{ terraform_dl_loc }}
   get_url:
-    url: "{{ terraform_dl_url }}/{{ terraform_app }}/{{ terraform_version }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    url: "{{ terraform_dl_url }}/{{ terraform_app }}/{{ terraform_version }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     dest: "{{ terraform_dl_loc }}"
 
-# - name: Gather package facts to verify if unzip is installed on EL based systems
-#   package_facts:
-#     manager: rpm
 
-- name: EL Family | Install unzip if it is currently not in an installed state
+- name: EL Family | Install unzip if it is currently not in installed state
   yum:
     name: unzip
     state: present
     update_cache: yes
-    # when: packages['unzip'] is not defined
 
-- name: EL Family | Extract {{ terraform_app }} archive
+- name: EL Family | Unarchive {{ terraform_app }} {{ terraform_version }}
   unarchive:
-    src: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    src: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     dest: "{{ terraform_bin_path }}"
+    owner: "{{ terraform_file_owner }}"
+    group: "{{ terraform_file_group }}"
+    mode: "{{ terraform_file_mode }}"
     remote_src: true
 
-- name: EL Family | {{ terraform_app }}_archive_removal
+- name: EL Family | Remove {{ terraform_app }} archive
   file:
-    path: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_osarch }}.zip"
+    path: "{{ terraform_dl_loc }}/{{ terraform_app }}_{{ terraform_version }}_{{ terraform_os }}_{{ terraform_arch }}.zip"
     state: absent


### PR DESCRIPTION
- Utilize github actions/checkout@v2 and Python 3.10.0 in build-and-test workflow
- Utilize github actions/checkout@v2 and Python 3.10.0 in release workflow
- Separate out variables for OS and Arch
- Set owner and group for `terraform` file.
- Bump `terraform` to 1.1.4